### PR TITLE
Exit gracefully if kubeconfig doesn't exist in path provided.

### DIFF
--- a/lookup/list.go
+++ b/lookup/list.go
@@ -67,11 +67,11 @@ func getClientSet() (*kubernetes.Clientset, error) {
 	flag.Parse()
 
 
-  if _, err := os.Stat(kubeconfig); err != nil {
-    // kubeconfig doesn't exist
-    fmt.Printf("%s does not exist - please make sure you have a kubeconfig configured.\n", kubeconfig)
-    os.Exit(1)
-  }
+        if _, err := os.Stat(kubeconfig); err != nil {
+          // kubeconfig doesn't exist
+          fmt.Printf("%s does not exist - please make sure you have a kubeconfig configured.\n", kubeconfig)
+          os.Exit(1)
+        }
 
 	// use the current context in kubeconfig
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)

--- a/lookup/list.go
+++ b/lookup/list.go
@@ -66,6 +66,13 @@ func getClientSet() (*kubernetes.Clientset, error) {
 	}
 	flag.Parse()
 
+
+  if _, err := os.Stat(kubeconfig); err != nil {
+    // kubeconfig doesn't exist
+    fmt.Printf("%s does not exist - please make sure you have a kubeconfig configured.\n", kubeconfig)
+    os.Exit(1)
+  }
+
 	// use the current context in kubeconfig
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {


### PR DESCRIPTION
I added a statement to check that a kubeconfig exists in the path provided, and if it does not exist, exit gracefully.